### PR TITLE
Add langtags repo staging build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ Github action practice repository for Language Technology conference 2022
 - https://github.com/sillsdev/Mercurial4Chorus/blob/master/.github/workflows/nuget-ci-cd.yml (builds Nuget package and publishes to Nuget using Secrets)
 - https://github.com/sillsdev/SpeechAnalyzer/blob/master/.github/workflows/msbuild.yml
 - https://github.com/sillsdev/SpeechAnalyzer/blob/master/.github/workflows/parse-langtags.yml
+- https://github.com/silnrsi/langtags/blob/master/.github/workflows/staging.yml (builds langtags.json from pre-built SLDR artifacts on another repo see section headed "# Download the external artefact dependencies")


### PR DESCRIPTION
An example of how to get to a large external artefact from another repo, cache and re-use it on subsequent builds if unchanged upstream.